### PR TITLE
fixes #1191 CppSharp.CLI.exe --rtti sets -fno-rtti to clang

### DIFF
--- a/src/CLI/Generator.cs
+++ b/src/CLI/Generator.cs
@@ -152,6 +152,9 @@ namespace CppSharp
             if (abi == CppAbi.Microsoft)
                 parserOptions.MicrosoftMode = true;
 
+            parserOptions.UnityBuild = options.UnityBuild;
+            parserOptions.EnableRTTI = options.EnableRTTI;
+
             parserOptions.Setup();
 
             if (triple.Contains("linux"))
@@ -173,9 +176,6 @@ namespace CppSharp
                 else
                     parserOptions.AddDefines(d.Key + "=" + d.Value);
             }
-
-            parserOptions.UnityBuild = options.UnityBuild;
-            parserOptions.EnableRTTI = options.EnableRTTI;
 
             if (options.EnableExceptions)
                 parserOptions.AddArguments("-fcxx-exceptions");


### PR DESCRIPTION
The problem being fixed is that although --rtti is given as argument to
CppSharp.CLI.exe the runtime type information is turned off. The error
is happening because the Generator options are copied over to the
parserOptions after the parserOptions have been used to generate the
cmake call. Thus, the default value of RTTI (off) is always evaluated
and cmake will always get the parameter -fno-rtti.
The same issue seems to apply to the unity build.

This patch fixes the issue by moving the 2 assignments of Generator
options properties into ParserOptions properties before they are
evaluated in parserOptions.Setup();